### PR TITLE
counting field datatype specification

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,10 @@
 name = "TropicalNumbers"
 uuid = "b3a74e9c-7526-4576-a4eb-79c0d4c32334"
 authors = ["GiggleLiu"]
-version = "0.2.3"
+version = "0.3.0"
 
 [compat]
-julia = "1.0,1.4"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/TropicalNumbers.jl
+++ b/src/TropicalNumbers.jl
@@ -10,20 +10,19 @@ include("counting_tropical.jl")
 
 const TropicalTypes{T} = Union{CountingTropical{T}, Tropical{T}}
 
+# alias
+for NBIT in [16, 32, 64]
+    @eval const $(Symbol(:Tropical, :F, NBIT)) = Tropical{$(Symbol(:Float, NBIT))}
+    @eval const $(Symbol(:CountingTropical, :F, NBIT)) = CountingTropical{$(Symbol(:Float, NBIT)),$(Symbol(:Float, NBIT))}
+end
+
+# alias
 for T in [:Tropical, :CountingTropical]
     # defining constants like `TropicalF64`.
-    for NBIT in [16, 32, 64]
-        @eval const $(Symbol(T, :F, NBIT)) = $T{$(Symbol(:Float, NBIT))}
-    end
     for OP in [:>, :<, :(==), :>=, :<=, :isless]
         @eval Base.$OP(a::$T, b::$T) = $OP(a.n, b.n)
     end
     @eval begin
-        # promotion rules
-        @inline _create_type(::Type{$T}, ::Type{IT}) where {IT} = $T{IT}
-        @inline _create_type(::Type{$T}, ::Type{Union{}}) where {IT} = Union{}
-        Base.promote_rule(::Type{$T{T1}}, b::Type{$T{T2}}) where {T1, T2} = _create_type($T, promote_rule(T1,T2))
-
         content(x::$T) = x.n
         content(x::Type{$T{X}}) where X = X
         Base.isapprox(x::AbstractArray{<:$T}, y::AbstractArray{<:$T}; kwargs...) = all(isapprox.(x, y; kwargs...))

--- a/src/counting_tropical.jl
+++ b/src/counting_tropical.jl
@@ -33,7 +33,4 @@ Base.isapprox(a::CountingTropical, b::CountingTropical; kwargs...) = isapprox(a.
 
 Base.show(io::IO, t::CountingTropical) = Base.print(io, "$((t.n, t.c))ₜ")
 
-#Base.promote_type(::Type{CountingTropical{T1,CT1}}, b::Type{CountingTropical{T1,CT1}}) where {T1,CT1} = CountingTropical{T1, CT1}
 Base.promote_type(::Type{CountingTropical{T1,CT1}}, b::Type{CountingTropical{T2,CT2}}) where {T1,T2,CT1,CT2} = CountingTropical{promote_type(T1,T2), promote_type(CT1,CT2)}
-#Base.promote_type(::Type{CountingTropical{T1,CT1}}, b::Type{CountingTropical{T1,CT2}}) where {T1,CT1,CT2} = CountingTropical{T1, promote_rule(CT1,CT2)}
-#Base.promote_type(::Type{CountingTropical{T1,CT1}}, b::Type{CountingTropical{T2,CT1}}) where {T1,T2,CT1} = CountingTropical{promote_rule(T1,T2), CT1}

--- a/src/counting_tropical.jl
+++ b/src/counting_tropical.jl
@@ -1,12 +1,14 @@
-struct CountingTropical{T} <: Number
+struct CountingTropical{T,CT} <: Number
     n::T
-    c::T
+    c::CT
 end
 CountingTropical(x::T) where T<:Real = CountingTropical(x, T(1))
-CountingTropical{T1}(x::T2) where {T1, T2} = CountingTropical{T1}(T1(x), T1(1))
-CountingTropical{T1}(x::CountingTropical{T1}) where {T1} = x
-CountingTropical{T1}(x::CountingTropical{T2}) where {T1,T2} = CountingTropical(T1(x.n), T1(x.c))
-CountingTropical{T1}(x::Tropical{T2}) where {T1, T2} = CountingTropical(T1(TropicalNumbers.content(x)), T1(1))
+CountingTropical{T1}(x) where {T1} = CountingTropical{T1,T1}(x)
+
+CountingTropical{T1,CT1}(x) where {T1, CT1} = CountingTropical{T1,CT1}(T1(x), CT1(1))
+CountingTropical{T1,CT1}(x::CountingTropical{T1,CT1}) where {T1,CT1} = x
+CountingTropical{T1,CT1}(x::CountingTropical) where {T1,CT1} = CountingTropical(T1(x.n), CT1(x.c))
+CountingTropical{T1,CT1}(x::Tropical) where {T1,CT1} = CountingTropical{T1,CT1}(T1(TropicalNumbers.content(x)), CT1(1))
 
 Base.:*(a::CountingTropical, b::CountingTropical) = CountingTropical(a.n + b.n, a.c * b.c)
 function Base.:+(a::CountingTropical, b::CountingTropical)
@@ -20,12 +22,18 @@ function Base.:+(a::CountingTropical, b::CountingTropical)
     end
     CountingTropical(n, c)
 end
-Base.zero(::Type{CountingTropical{T}}) where T<:Integer = CountingTropical(T(-999999), T(0))
-Base.zero(::Type{CountingTropical{T}}) where T<:AbstractFloat = CountingTropical(typemin(T), T(0))
-Base.one(::Type{CountingTropical{T}}) where T<:Integer = CountingTropical(zero(T), T(1))
-Base.one(::Type{CountingTropical{T}}) where T<:AbstractFloat = CountingTropical(zero(T), T(1))
-Base.one(x::T) where T<:CountingTropical = one(T)
-Base.zero(x::T) where T<:CountingTropical = zero(T)
+Base.zero(::Type{CountingTropical{T}}) where T = zero(CountingTropical{T,T})
+Base.zero(::Type{CountingTropical{T,CT}}) where {T<:Integer,CT} = CountingTropical(T(-999999), CT(0))
+Base.zero(::Type{CountingTropical{T,CT}}) where {T<:AbstractFloat,CT} = CountingTropical(typemin(T), CT(0))
+Base.one(::Type{CountingTropical{T,CT}}) where {T<:Integer,CT} = CountingTropical(zero(T), CT(1))
+Base.one(::Type{CountingTropical{T,CT}}) where {T<:AbstractFloat,CT} = CountingTropical(zero(T), CT(1))
+Base.one(::T) where T<:CountingTropical = one(T)
+Base.zero(::T) where T<:CountingTropical = zero(T)
 Base.isapprox(a::CountingTropical, b::CountingTropical; kwargs...) = isapprox(a.n, b.n; kwargs...) && isapprox(a.c, b.c; kwargs...)
 
 Base.show(io::IO, t::CountingTropical) = Base.print(io, "$((t.n, t.c))ₜ")
+
+#Base.promote_type(::Type{CountingTropical{T1,CT1}}, b::Type{CountingTropical{T1,CT1}}) where {T1,CT1} = CountingTropical{T1, CT1}
+Base.promote_type(::Type{CountingTropical{T1,CT1}}, b::Type{CountingTropical{T2,CT2}}) where {T1,T2,CT1,CT2} = CountingTropical{promote_type(T1,T2), promote_type(CT1,CT2)}
+#Base.promote_type(::Type{CountingTropical{T1,CT1}}, b::Type{CountingTropical{T1,CT2}}) where {T1,CT1,CT2} = CountingTropical{T1, promote_rule(CT1,CT2)}
+#Base.promote_type(::Type{CountingTropical{T1,CT1}}, b::Type{CountingTropical{T2,CT1}}) where {T1,T2,CT1} = CountingTropical{promote_rule(T1,T2), CT1}

--- a/src/tropical.jl
+++ b/src/tropical.jl
@@ -43,6 +43,4 @@ Base.one(::Tropical{T}) where T = one(Tropical{T})
 Base.isapprox(x::Tropical, y::Tropical; kwargs...) = isapprox(x.n, y.n; kwargs...)
 
 # promotion rules
-@inline _create_type(::Type{Tropical}, ::Type{IT}) where {IT} = Tropical{IT}
-@inline _create_type(::Type{Tropical}, ::Type{Union{}}) = Union{}
-Base.promote_rule(::Type{Tropical{T1}}, b::Type{Tropical{T2}}) where {T1, T2} = _create_type(Tropical, promote_rule(T1,T2))
+Base.promote_type(::Type{Tropical{T1}}, b::Type{Tropical{T2}}) where {T1, T2} = Tropical{promote_type(T1,T2)}

--- a/src/tropical.jl
+++ b/src/tropical.jl
@@ -41,3 +41,8 @@ Base.one(::Type{Tropical{T}}) where T = Tropical(zero(T))
 Base.one(::Tropical{T}) where T = one(Tropical{T})
 
 Base.isapprox(x::Tropical, y::Tropical; kwargs...) = isapprox(x.n, y.n; kwargs...)
+
+# promotion rules
+@inline _create_type(::Type{Tropical}, ::Type{IT}) where {IT} = Tropical{IT}
+@inline _create_type(::Type{Tropical}, ::Type{Union{}}) = Union{}
+Base.promote_rule(::Type{Tropical{T1}}, b::Type{Tropical{T2}}) where {T1, T2} = _create_type(Tropical, promote_rule(T1,T2))

--- a/test/counting_tropical.jl
+++ b/test/counting_tropical.jl
@@ -31,4 +31,5 @@ using TropicalNumbers
 
     @test promote(CountingTropical{Float64,Float32}(1, 2), CountingTropical{Int64,Int32}(1, 2)) == (CountingTropical{Float64,Float32}(1, 2), CountingTropical{Float64,Float32}(1, 2))
     @test promote(CountingTropical{Float64,Float32}(1, 2)) == (CountingTropical{Float64,Float32}(1, 2),)
+    @test promote_type(CountingTropical{Float64,Float32}, CountingTropicalF32, CountingTropical{Int32,Int32}) == CountingTropical{Float64,Float32}
 end

--- a/test/counting_tropical.jl
+++ b/test/counting_tropical.jl
@@ -21,4 +21,14 @@ using TropicalNumbers
     ct2 = CountingTropical(2.0, 3.0)
     @test CountingTropicalF64(ct1) === CountingTropical(2.0, 4.0)
     @test promote(ct1, ct2) === (CountingTropical(2.0, 4.0), ct2)
+
+    @test CountingTropical{Float64}(2) === CountingTropical{Float64,Float64}(2.0, 1.0)
+    @test CountingTropical{Int64, Float64}(2) === CountingTropical{Int64,Float64}(2, 1.0)
+    @test CountingTropical{Int64, Float64}(TropicalF64(2)) === CountingTropical{Int64,Float64}(2, 1.0)
+    @test CountingTropical{Int64, Float64}(CountingTropicalF64(2)) === CountingTropical{Int64,Float64}(2, 1.0)
+    @test zero(CountingTropical{Int64,Float64}) === CountingTropical{Int64,Float64}(-999999, 0.0)
+    @test one(CountingTropical{Int64,Float64}) === CountingTropical{Int64,Float64}(0, 1.0)
+
+    @test promote(CountingTropical{Float64,Float32}(1, 2), CountingTropical{Int64,Int32}(1, 2)) == (CountingTropical{Float64,Float32}(1, 2), CountingTropical{Float64,Float32}(1, 2))
+    @test promote(CountingTropical{Float64,Float32}(1, 2)) == (CountingTropical{Float64,Float32}(1, 2),)
 end

--- a/test/tropical.jl
+++ b/test/tropical.jl
@@ -33,4 +33,7 @@ using TropicalNumbers
     @test promote(t1, t2) === (Tropical(2.0), t2)
 
     @test content(TropicalF64) == Float64
+
+    @test promote(Tropical{Float64}(1), Tropical{Int64}(2)) == (Tropical{Float64}(1), Tropical{Float64}(2))
+    @test promote(Tropical{Float64}(1)) == (Tropical{Float64}(1),)
 end

--- a/test/tropical.jl
+++ b/test/tropical.jl
@@ -36,4 +36,6 @@ using TropicalNumbers
 
     @test promote(Tropical{Float64}(1), Tropical{Int64}(2)) == (Tropical{Float64}(1), Tropical{Float64}(2))
     @test promote(Tropical{Float64}(1)) == (Tropical{Float64}(1),)
+    @test promote_type(Tropical{Float64}, TropicalF32) == TropicalF64
+    @test promote_type(Tropical{Float64}, TropicalF32, Tropical{Int32}) == TropicalF64
 end


### PR DESCRIPTION
Allowing the counting field type being different from the counting field type.
```julia
CoutingTropical{T} -> CountingTropical{T,CT}
````