### PR TITLE
fix the isapprox for TropicalAndOr

### DIFF
--- a/src/tropical_andor.jl
+++ b/src/tropical_andor.jl
@@ -50,4 +50,4 @@ Base.one(::TropicalAndOr) = one(TropicalAndOr)
 Base.inv(x::TropicalAndOr) = TropicalAndOr(!x.n)
 
 # bool type only have two values
-Base.isapprox(x::TropicalAndOr, y::TropicalAndOr; kwargs...) = ispprox(x.n, y.n; kwargs...)
+Base.isapprox(x::TropicalAndOr, y::TropicalAndOr; kwargs...) = isapprox(x.n, y.n; kwargs...)

--- a/test/tropical_andor.jl
+++ b/test/tropical_andor.jl
@@ -17,6 +17,7 @@ using TropicalNumbers
 
     @test zero(TropicalAndOr) == TropicalAndOr(false)
     @test one(TropicalAndOr) == TropicalAndOr(true)
+    @test zero(TropicalAndOr) ≈ TropicalAndOr(false)
 
     println(TropicalAndOr(true))
 end


### PR DESCRIPTION
Sorry, I found I made a mistake when defining `isapprox` of `TropicalAndOr`, now it is fixed.