### PR TITLE
Implement promote_rule instead of promote_type

### DIFF
--- a/src/counting_tropical.jl
+++ b/src/counting_tropical.jl
@@ -62,4 +62,4 @@ Base.isapprox(a::CountingTropical, b::CountingTropical; kwargs...) = isapprox(a.
 
 Base.show(io::IO, t::CountingTropical) = Base.print(io, "$((t.n, t.c))ₜ")
 
-Base.promote_type(::Type{CountingTropical{T1,CT1}}, b::Type{CountingTropical{T2,CT2}}) where {T1,T2,CT1,CT2} = CountingTropical{promote_type(T1,T2), promote_type(CT1,CT2)}
+Base.promote_rule(::Type{CountingTropical{T1,CT1}}, b::Type{CountingTropical{T2,CT2}}) where {T1,T2,CT1,CT2} = CountingTropical{promote_type(T1,T2), promote_type(CT1,CT2)}

--- a/src/tropical_maxmul.jl
+++ b/src/tropical_maxmul.jl
@@ -67,4 +67,4 @@ Base.div(x::TropicalMaxMul, y::TropicalMaxMul) = TropicalMaxMul(x.n ÷ y.n)
 Base.isapprox(x::TropicalMaxMul, y::TropicalMaxMul; kwargs...) = isapprox(x.n, y.n; kwargs...)
 
 # promotion rules
-Base.promote_type(::Type{TropicalMaxMul{T1}}, b::Type{TropicalMaxMul{T2}}) where {T1, T2} = TropicalMaxMul{promote_type(T1,T2)}
+Base.promote_rule(::Type{TropicalMaxMul{T1}}, b::Type{TropicalMaxMul{T2}}) where {T1, T2} = TropicalMaxMul{promote_type(T1,T2)}

--- a/src/tropical_maxplus.jl
+++ b/src/tropical_maxplus.jl
@@ -80,4 +80,4 @@ Base.div(x::Tropical, y::Tropical) = Tropical(x.n - y.n)
 Base.isapprox(x::Tropical, y::Tropical; kwargs...) = isapprox(x.n, y.n; kwargs...)
 
 # promotion rules
-Base.promote_type(::Type{Tropical{T1}}, b::Type{Tropical{T2}}) where {T1, T2} = Tropical{promote_type(T1,T2)}
+Base.promote_rule(::Type{Tropical{T1}}, b::Type{Tropical{T2}}) where {T1, T2} = Tropical{promote_type(T1,T2)}

--- a/src/tropical_minplus.jl
+++ b/src/tropical_minplus.jl
@@ -73,4 +73,4 @@ Base.div(x::TropicalMinPlus, y::TropicalMinPlus) = TropicalMinPlus(x.n - y.n)
 Base.isapprox(x::TropicalMinPlus, y::TropicalMinPlus; kwargs...) = isapprox(x.n, y.n; kwargs...)
 
 # promotion rules
-Base.promote_type(::Type{TropicalMinPlus{T1}}, b::Type{TropicalMinPlus{T2}}) where {T1, T2} = TropicalMinPlus{promote_type(T1,T2)}
+Base.promote_rule(::Type{TropicalMinPlus{T1}}, b::Type{TropicalMinPlus{T2}}) where {T1, T2} = TropicalMinPlus{promote_type(T1,T2)}


### PR DESCRIPTION
Fix #13 , @nsajko could you please help check if this fix is proper? I impemented the `promote_rule`, which calls into `promote_type` (If I use `promote_rule` for type parameters, the tests do not pass).